### PR TITLE
Rebrand README for 2026 — terminal-maximalist, biker not cyclist

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+# LinkedIn returns HTTP 999 for any non-browser User-Agent (anti-scraping).
+# The profile link is real; lychee just can't see it. Skip it.
+^https://www\.linkedin\.com/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Laravel Zero microkernel for the terminal era. Every API becomes a first-class L
 
 - [`conduit`](https://github.com/conduit-ui/conduit) — the core CLI
 - [`repos`](https://github.com/conduit-ui/repos) · [`prs`](https://github.com/conduit-ui/prs) · [`commits`](https://github.com/conduit-ui/commits) · [`issues`](https://github.com/conduit-ui/issues) — GitHub primitives, as first-class commands
+- [`knowledge`](https://github.com/conduit-ui/knowledge) — AI-powered knowledge base with semantic search + Qdrant
 - [`marketplace`](https://github.com/conduit-ui/marketplace) · [`conduit-component`](https://github.com/conduit-ui/conduit-component) — the extension surface
 
 ### [the-shit](https://github.com/the-shit) — Scaling humans into tomorrow
@@ -39,11 +40,10 @@ Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructur
 
 ## Personal namespace
 
-A few things I keep under my own name because they're tools, not platforms.
+A few clients I keep under my own name because they're tools, not platforms.
 
 - [`github-client`](https://github.com/jordanpartridge/github-client) — Saloon-powered GitHub for Laravel. GitHub that feels like Eloquent.
 - [`strava-client`](https://github.com/jordanpartridge/strava-client) — OAuth, webhooks, retries baked in. Fitness data, production-grade.
-- [`knowledge`](https://github.com/jordanpartridge/knowledge) — Personal knowledge gateway. Multi-model AI routing, semantic search, the brain behind the agents.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jordan Partridge
 
-```
+```text
 jordan@partridge.rocks:~$ whoami
 Jordan Partridge — builder. Laravel for the spine. Agents for the leverage.
 Self-hosted by choice. Terminal-first by conviction.
@@ -32,8 +32,8 @@ Laravel Zero microkernel for the terminal era. Every API becomes a first-class L
 
 Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructure lives — the workflows, memory, and swarms that turn one human into a small team without hiring one. If shit ain't tight, shit ain't right.
 
-- [`agents`](https://github.com/the-shit/agents) · [`swarm`](https://github.com/the-shit/swarm) · [`pr-agent`](https://github.com/the-shit/pr-agent) — orchestration
-- [`claude-mem`](https://github.com/the-shit/claude-mem) · [`mindkeeper`](https://github.com/the-shit/mindkeeper) · [`vector`](https://github.com/the-shit/vector) — memory and recall
+- [`agents`](https://github.com/the-shit/agents) · [`agent-skeleton`](https://github.com/the-shit/agent-skeleton) · [`agent-devbox`](https://github.com/the-shit/agent-devbox) — orchestration + scaffolding
+- [`claude-mem`](https://github.com/the-shit/claude-mem) · [`vector`](https://github.com/the-shit/vector) — memory and recall
 - [`music`](https://github.com/the-shit/music) · [`chat`](https://github.com/the-shit/chat) — the human side of the loop
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,211 +1,70 @@
 # Jordan Partridge
 
-<div align="center">
-
 ```
-  ██████╗ ██████╗ ███╗   ██╗██████╗ ██╗   ██╗██╗████████╗
- ██╔════╝██╔═══██╗████╗  ██║██╔══██╗██║   ██║██║╚══██╔══╝
- ██║     ██║   ██║██╔██╗ ██║██║  ██║██║   ██║██║   ██║
- ██║     ██║   ██║██║╚██╗██║██║  ██║██║   ██║██║   ██║
- ╚██████╗╚██████╔╝██║ ╚████║██████╔╝╚██████╔╝██║   ██║
-  ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝╚═════╝  ╚═════╝ ╚═╝   ╚═╝
+jordan@odin:~$ whoami
+Jordan Partridge — builder. Laravel for the spine. Agents for the leverage.
+Self-hosted by choice. Terminal-first by conviction.
+
+jordan@odin:~$ uptime
+2026 — devs came home to the terminal. About time.
 ```
 
-**Developer Liberation Platform** · Laravel Advocate · AI Workflow Pioneer
-
-*Building tools that understand your code, respect your time, and amplify your impact*
-
-[![Website](https://img.shields.io/badge/jordanpartridge.us-FF7139?style=flat-square&logo=firefox-browser&logoColor=white)](https://jordanpartridge.us)
-[![LinkedIn](https://img.shields.io/badge/Connect-0077B5?style=flat-square&logo=linkedin)](https://www.linkedin.com/in/jordan-l-partridge)
-
-</div>
+[![Site](https://img.shields.io/badge/jordanpartridge.us-1a1b27?style=flat-square)](https://jordanpartridge.us)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0a66c2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jordan-l-partridge)
 
 ---
 
-## What I'm Building
+## the-shit — Scaling humans into tomorrow
 
-> **"Use AI to fade out the background noise"**
+Less ceremony. More ship. The work below is the working theory.
 
-I believe developers deserve tools that work *with* them, not against them.
-My work centers on three pillars:
+## What I Ship
 
-**1. Developer Liberation** - Break free from corporate toolchain tyranny
-**2. AI-Powered Workflows** - Let machines handle the mundane
-**3. Developer Wellbeing** - Because it's not just about shipping code
+**[conduit-ui](https://github.com/conduit-ui)** — Laravel Zero microkernel that makes every API a first-class Laravel citizen. Integrate all the things.
 
----
+**[the-shit](https://github.com/the-shit)** — Scaling humans into tomorrow. The umbrella for the weird, useful stuff.
 
-## Featured Projects
+**[prefrontal-cortex](https://github.com/jordanpartridge/prefrontal-cortex)** — Personal memory + knowledge layer. The brain behind the agents.
 
-<table>
-<tr>
-<td width="50%" valign="top">
+**[github-client](https://github.com/jordanpartridge/github-client)** — Saloon-powered GitHub for Laravel. GitHub that feels like Eloquent.
 
-### [Conduit](https://github.com/conduit-ui/conduit)
+**[strava-client](https://github.com/jordanpartridge/strava-client)** — OAuth, webhooks, retries baked in. Fitness data, production-grade.
 
-**Developer Liberation Platform**
-
-Laravel Zero CLI with microkernel component architecture.
-Your personal developer API gateway.
-
-```bash
-conduit ask "where is auth handled?"
-conduit discover  # find community components
-```
-
-*The CLI that knows it's 2am and actually cares*
-
-![PHP](https://img.shields.io/badge/PHP_8.3-777BB4?style=flat-square&logo=php&logoColor=white)
-![Laravel Zero](https://img.shields.io/badge/Laravel_Zero-FF2D20?style=flat-square&logo=laravel&logoColor=white)
-
-</td>
-<td width="50%" valign="top">
-
-### [github-client](https://github.com/jordanpartridge/github-client)
-
-**Laravel GitHub API Wrapper** ⭐ 4
-
-Saloon-powered GitHub integration that plays nice with Laravel.
-
-```php
-GitHub::repo('owner/repo')->issues()->list();
-```
-
-*Because GitHub integrations should feel like first-class Laravel citizens*
-
-![Stars](https://img.shields.io/github/stars/jordanpartridge/github-client?style=flat-square)
-![PHP](https://img.shields.io/badge/Saloon-777BB4?style=flat-square&logo=php&logoColor=white)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-### [chat](https://github.com/jordanpartridge/chat)
-
-**Multi-Model AI Chat**
-
-Compare AI models side-by-side. Laravel 12 + Vue 3 + Inertia.js.
-
-*Switch between Claude, GPT-4, and more in a modern SPA*
-
-![Laravel 12](https://img.shields.io/badge/Laravel_12-FF2D20?style=flat-square&logo=laravel&logoColor=white)
-![Vue 3](https://img.shields.io/badge/Vue_3-4FC08D?style=flat-square&logo=vue.js&logoColor=white)
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
-
-</td>
-<td width="50%" valign="top">
-
-### [claude-code-agents](https://github.com/jordanpartridge/claude-code-agents)
-
-**AI Workflow Automation**
-
-Specialized Claude Code agents for GitHub operations.
-
-```text
-"Commit my work and create a PR"
-→ semantic commits → PR with description → done
-```
-
-*Turn scattered repos into orchestrated workflows*
-
-![Claude](https://img.shields.io/badge/Claude_Code-000000?style=flat-square&logo=anthropic&logoColor=white)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-### [strava-client](https://github.com/jordanpartridge/strava-client)
-
-**Laravel Strava Integration**
-
-Production-ready OAuth, webhooks, intelligent retry.
-
-**76 tests · 198 assertions · PHPStan Level 5**
-
-*Your fitness API integration shouldn't be harder than your workout*
-
-![Tests](https://img.shields.io/badge/Tests-76_passing-brightgreen?style=flat-square)
-![Coverage](https://img.shields.io/badge/Coverage-Tracked-blue?style=flat-square)
-
-</td>
-<td width="50%" valign="top">
-
-### [conduit-knowledge](https://github.com/jordanpartridge/conduit-knowledge)
-
-**AI-Powered Knowledge Base**
-
-Git-aware knowledge capture with semantic search.
-
-```bash
-conduit knowledge add "TIL: Laravel 12 has..."
-conduit knowledge search "auth patterns"
-```
-
-*Your codebase's memory: never lose what you learned*
-
-![PHP](https://img.shields.io/badge/Laravel_Zero-FF2D20?style=flat-square&logo=laravel&logoColor=white)
-
-</td>
-</tr>
-</table>
+**[fat-bike-corps](https://github.com/fat-bike-corps)** — Bikes, brains, and the loop between them.
 
 ---
 
-## The Ecosystem
+## On the Bike
 
-```mermaid
-flowchart TB
-    subgraph platform["CONDUIT PLATFORM"]
-        direction TB
-        subgraph clients["API Clients"]
-            gh[github-client]
-            st[strava-client]
-            sp[spotify-client]
-        end
-        clients --> knowledge[conduit-knowledge]
-        knowledge --> conduit[Conduit CLI]
-    end
+Biker, not cyclist. Mornings are coffee and mobility, then fat tires or e-bike pedals — whatever the body's asking for. Not chasing watts. Not training for the Tour. Stacking miles because the brain works better when the legs have done some work first.
 
-    style platform fill:#1a1b27,stroke:#7aa2f7,color:#c0caf5
-    style clients fill:#24283b,stroke:#7aa2f7
-    style knowledge fill:#ff9e64,stroke:#ff9e64,color:#1a1b27
-    style conduit fill:#9ece6a,stroke:#9ece6a,color:#1a1b27
-```
-
-*Code commits + Fitness + Music = Developer Wellbeing Intelligence*
+<!-- STRAVA:START -->
+*Live ride signal wiring up at `signal.jordanpartridge.us/widgets/readme.svg` — prefrontal-cortex feeding the render.*
+<!-- STRAVA:END -->
 
 ---
 
-## Philosophy
+## Built On
 
-**On Developer Tools:**
-> Every service should feel like Laravel. If it doesn't, I'll build a client for it.
-
-**On AI:**
-> AI should amplify developers, not replace them.
-> Let machines handle the mundane so you can focus on what matters.
-
-**On Wellbeing:**
-> If you're coding at 2am with lo-fi playing, maybe a gentle nudge
-> is more valuable than another productivity metric.
+Was going to build my own dev harness. Then [Aaron Francis](https://github.com/aarondfrancis) shipped [Solo](https://github.com/aarondfrancis/solo) — beyond what I'd have managed. Real ones build the rails the rest of us run on. Check it out.
 
 ---
 
 ## Currently
 
-- Building **Conduit** - the Developer Liberation Platform
-- Exploring **AI-powered codebase understanding** with conduit-knowledge
-- Managing **50+ repos** with claude-code-agents (yes, AI managing AI)
-- Cycling and tracking it with my own Strava integration
+<!-- CURRENT:START -->
+- Agent-swarm infrastructure on the conduit-ui spine
+- conduit-ui package push — every API a Laravel citizen
+- Ride volume on the fat bike and e-bike, tracked locally
+- Lexi running point — 3 orgs, 40+ repos, the Odin homelab
+<!-- CURRENT:END -->
 
 ---
 
 <div align="center">
 
-*Building tools for developers who care about craft, sustainability, and actually enjoying their work.*
+**Terminal maximalist • Self-hosted • Zero cloud**
 
-**[jordanpartridge.us](https://jordanpartridge.us)** · Fat bike fan · Perpetual optimist
+[jordanpartridge.us](https://jordanpartridge.us)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ```text
 jordan@partridge.rocks:~$ whoami
-Jordan Partridge — builder. Laravel for the spine. Agents for the leverage.
-Self-hosted by choice. Terminal-first by conviction.
+Senior Laravel Engineer · terminal maximalist · self-hosted by choice
 
 jordan@partridge.rocks:~$ uptime
 2026 — devs came home to the terminal. About time.
@@ -21,39 +20,29 @@ The work lives in two orgs. Each has a job. Each has a vision.
 
 ### [conduit-ui](https://github.com/conduit-ui) — Integrate all the things
 
-Laravel Zero microkernel for the terminal era. Every API becomes a first-class Laravel citizen — GitHub, Strava, whatever you wire next. Components compose like Eloquent. The CLI as the integration layer, not a thin wrapper around someone else's UI.
+Laravel Zero microkernel for the terminal era. The [`conduit`](https://github.com/conduit-ui/conduit) CLI is the user-facing surface; everything else is the ecosystem that makes it more than a one-man tool.
 
-- [`conduit`](https://github.com/conduit-ui/conduit) — the core CLI
-- [`repos`](https://github.com/conduit-ui/repos) · [`prs`](https://github.com/conduit-ui/prs) · [`commits`](https://github.com/conduit-ui/commits) · [`issues`](https://github.com/conduit-ui/issues) — GitHub primitives, as first-class commands
-- [`knowledge`](https://github.com/conduit-ui/knowledge) — AI-powered knowledge base with semantic search + Qdrant
-- [`marketplace`](https://github.com/conduit-ui/marketplace) · [`conduit-component`](https://github.com/conduit-ui/conduit-component) — the extension surface
+- [`core`](https://github.com/conduit-ui/core) — the microkernel. Shared services, interfaces, component management. Everything else orbits it.
+- [`conduit-component`](https://github.com/conduit-ui/conduit-component) — scaffold for first-class components. Turns one-off scripts into ecosystem citizens.
+- [`marketplace`](https://github.com/conduit-ui/marketplace) — Claude Code plugins marketplace for the Conduit UI ecosystem.
+- [`knowledge`](https://github.com/conduit-ui/knowledge) — AI-powered knowledge base with semantic search + Qdrant.
 
 ### [the-shit](https://github.com/the-shit) — Scaling humans into tomorrow
 
-Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructure lives — the workflows, memory, and swarms that turn one human into a small team without hiring one. If shit ain't tight, shit ain't right.
+Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructure lives — workflows, memory, the loop between human and machine. If shit ain't tight, shit ain't right.
 
-- [`agents`](https://github.com/the-shit/agents) · [`agent-skeleton`](https://github.com/the-shit/agent-skeleton) — orchestration + base template
-- [`claude-mem`](https://github.com/the-shit/claude-mem) · [`vector`](https://github.com/the-shit/vector) — memory and recall
-- [`faster`](https://github.com/the-shit/faster) · [`music`](https://github.com/the-shit/music) · [`chat`](https://github.com/the-shit/chat) — voice, music, and the human side of the loop
+- [`core`](https://github.com/the-shit/core) — event bus + component runtime. The wiring under "Scaling humans into tomorrow."
+- [`agents`](https://github.com/the-shit/agents) — autonomous agent service. Container spawning, the daemon, GitHub App interface. Where the real work happens.
+- [`music`](https://github.com/the-shit/music) — Spotify CLI that rips. 35 commands, MCP server, AI-powered sessions. No GUI, no Electron. Proof a terminal can feel good.
 
 ---
 
 ## Personal namespace
 
-A few clients I keep under my own name because they're tools, not platforms.
+A couple of clients I keep under my own name because they're tools, not platforms.
 
 - [`github-client`](https://github.com/jordanpartridge/github-client) — Saloon-powered GitHub for Laravel. GitHub that feels like Eloquent.
 - [`strava-client`](https://github.com/jordanpartridge/strava-client) — OAuth, webhooks, retries baked in. Fitness data, production-grade.
-
----
-
-## On the Bike
-
-Biker, not cyclist. Mornings are coffee and mobility, then fat tires or e-bike pedals — whatever the body's asking for. Not chasing watts. Not training for the Tour. Stacking miles because the brain works better when the legs have done some work first.
-
-<!-- STRAVA:START -->
-*Live ride signal wiring up at `signal.jordanpartridge.us/widgets/readme.svg` — knowledge layer feeding the render.*
-<!-- STRAVA:END -->
 
 ---
 
@@ -63,18 +52,20 @@ Was going to build my own dev harness. Then [Aaron Francis](https://github.com/a
 
 ---
 
-## Currently
+## Current obsessions
 
 <!-- CURRENT:START -->
-- Agent-swarm infrastructure on the conduit-ui spine
-- conduit-ui package push — every API a Laravel citizen
-- Ride volume on the fat bike and e-bike, tracked locally
-- Lexi running point — 3 orgs, 40+ repos, the Odin homelab
+- **Voice-first coding** — talking to agents beats typing at them
+- **Agent swarms on the conduit-ui spine** — every API a Laravel citizen
+- **Zero-trust homelab** — self-hosted everything, Lexi running point across 3 orgs and 40+ repos
+- **Local-first telemetry** — track everything, leak nothing
 <!-- CURRENT:END -->
 
 ---
 
 <div align="center">
+
+Biker, not cyclist. · Self-hosted > cloud. · Ship small. Ship often. Ship clean.
 
 **Terminal maximalist • Self-hosted • Zero cloud**
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Laravel Zero microkernel for the terminal era. Every API becomes a first-class L
 
 Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructure lives — the workflows, memory, and swarms that turn one human into a small team without hiring one. If shit ain't tight, shit ain't right.
 
-- [`agents`](https://github.com/the-shit/agents) · [`agent-skeleton`](https://github.com/the-shit/agent-skeleton) · [`agent-devbox`](https://github.com/the-shit/agent-devbox) — orchestration + scaffolding
+- [`agents`](https://github.com/the-shit/agents) · [`agent-skeleton`](https://github.com/the-shit/agent-skeleton) — orchestration + base template
 - [`claude-mem`](https://github.com/the-shit/claude-mem) · [`vector`](https://github.com/the-shit/vector) — memory and recall
-- [`music`](https://github.com/the-shit/music) · [`chat`](https://github.com/the-shit/chat) — the human side of the loop
+- [`faster`](https://github.com/the-shit/faster) · [`music`](https://github.com/the-shit/music) · [`chat`](https://github.com/the-shit/chat) — voice, music, and the human side of the loop
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Jordan Partridge
 
 ```
-jordan@patridge.rocks:~$ whoami
+jordan@partridge.rocks:~$ whoami
 Jordan Partridge — builder. Laravel for the spine. Agents for the leverage.
 Self-hosted by choice. Terminal-first by conviction.
 
-jordan@patridge.rocks:~$ uptime
+jordan@partridge.rocks:~$ uptime
 2026 — devs came home to the terminal. About time.
 ```
 
 [![Site](https://img.shields.io/badge/jordanpartridge.us-1a1b27?style=flat-square)](https://jordanpartridge.us)
-[![Email](https://img.shields.io/badge/jordan%40patridge.rocks-1a1b27?style=flat-square&logo=maildotru&logoColor=white)](mailto:jordan@patridge.rocks)
+[![Email](https://img.shields.io/badge/jordan%40partridge.rocks-1a1b27?style=flat-square&logo=maildotru&logoColor=white)](mailto:jordan@partridge.rocks)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0a66c2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jordan-l-partridge)
 
 ---
@@ -78,6 +78,6 @@ Was going to build my own dev harness. Then [Aaron Francis](https://github.com/a
 
 **Terminal maximalist • Self-hosted • Zero cloud**
 
-[jordanpartridge.us](https://jordanpartridge.us) · [jordan@patridge.rocks](mailto:jordan@patridge.rocks)
+[jordanpartridge.us](https://jordanpartridge.us) · [jordan@partridge.rocks](mailto:jordan@partridge.rocks)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,36 +1,49 @@
 # Jordan Partridge
 
 ```
-jordan@odin:~$ whoami
+jordan@patridge.rocks:~$ whoami
 Jordan Partridge — builder. Laravel for the spine. Agents for the leverage.
 Self-hosted by choice. Terminal-first by conviction.
 
-jordan@odin:~$ uptime
+jordan@patridge.rocks:~$ uptime
 2026 — devs came home to the terminal. About time.
 ```
 
 [![Site](https://img.shields.io/badge/jordanpartridge.us-1a1b27?style=flat-square)](https://jordanpartridge.us)
+[![Email](https://img.shields.io/badge/jordan%40patridge.rocks-1a1b27?style=flat-square&logo=maildotru&logoColor=white)](mailto:jordan@patridge.rocks)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0a66c2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jordan-l-partridge)
 
 ---
 
-## the-shit — Scaling humans into tomorrow
+## The Orgs
 
-Less ceremony. More ship. The work below is the working theory.
+The work lives in two orgs. Each has a job. Each has a vision.
 
-## What I Ship
+### [conduit-ui](https://github.com/conduit-ui) — Integrate all the things
 
-**[conduit-ui](https://github.com/conduit-ui)** — Laravel Zero microkernel that makes every API a first-class Laravel citizen. Integrate all the things.
+Laravel Zero microkernel for the terminal era. Every API becomes a first-class Laravel citizen — GitHub, Strava, whatever you wire next. Components compose like Eloquent. The CLI as the integration layer, not a thin wrapper around someone else's UI.
 
-**[the-shit](https://github.com/the-shit)** — Scaling humans into tomorrow. The umbrella for the weird, useful stuff.
+- [`conduit`](https://github.com/conduit-ui/conduit) — the core CLI
+- [`repos`](https://github.com/conduit-ui/repos) · [`prs`](https://github.com/conduit-ui/prs) · [`commits`](https://github.com/conduit-ui/commits) · [`issues`](https://github.com/conduit-ui/issues) — GitHub primitives, as first-class commands
+- [`marketplace`](https://github.com/conduit-ui/marketplace) · [`conduit-component`](https://github.com/conduit-ui/conduit-component) — the extension surface
 
-**[prefrontal-cortex](https://github.com/jordanpartridge/prefrontal-cortex)** — Personal memory + knowledge layer. The brain behind the agents.
+### [the-shit](https://github.com/the-shit) — Scaling humans into tomorrow
 
-**[github-client](https://github.com/jordanpartridge/github-client)** — Saloon-powered GitHub for Laravel. GitHub that feels like Eloquent.
+Yes, the name's a wink. *Also* the thesis. This is where the agent infrastructure lives — the workflows, memory, and swarms that turn one human into a small team without hiring one. If shit ain't tight, shit ain't right.
 
-**[strava-client](https://github.com/jordanpartridge/strava-client)** — OAuth, webhooks, retries baked in. Fitness data, production-grade.
+- [`agents`](https://github.com/the-shit/agents) · [`swarm`](https://github.com/the-shit/swarm) · [`pr-agent`](https://github.com/the-shit/pr-agent) — orchestration
+- [`claude-mem`](https://github.com/the-shit/claude-mem) · [`mindkeeper`](https://github.com/the-shit/mindkeeper) · [`vector`](https://github.com/the-shit/vector) — memory and recall
+- [`music`](https://github.com/the-shit/music) · [`chat`](https://github.com/the-shit/chat) — the human side of the loop
 
-**[fat-bike-corps](https://github.com/fat-bike-corps)** — Bikes, brains, and the loop between them.
+---
+
+## Personal namespace
+
+A few things I keep under my own name because they're tools, not platforms.
+
+- [`github-client`](https://github.com/jordanpartridge/github-client) — Saloon-powered GitHub for Laravel. GitHub that feels like Eloquent.
+- [`strava-client`](https://github.com/jordanpartridge/strava-client) — OAuth, webhooks, retries baked in. Fitness data, production-grade.
+- [`knowledge`](https://github.com/jordanpartridge/knowledge) — Personal knowledge gateway. Multi-model AI routing, semantic search, the brain behind the agents.
 
 ---
 
@@ -39,7 +52,7 @@ Less ceremony. More ship. The work below is the working theory.
 Biker, not cyclist. Mornings are coffee and mobility, then fat tires or e-bike pedals — whatever the body's asking for. Not chasing watts. Not training for the Tour. Stacking miles because the brain works better when the legs have done some work first.
 
 <!-- STRAVA:START -->
-*Live ride signal wiring up at `signal.jordanpartridge.us/widgets/readme.svg` — prefrontal-cortex feeding the render.*
+*Live ride signal wiring up at `signal.jordanpartridge.us/widgets/readme.svg` — knowledge layer feeding the render.*
 <!-- STRAVA:END -->
 
 ---
@@ -65,6 +78,6 @@ Was going to build my own dev harness. Then [Aaron Francis](https://github.com/a
 
 **Terminal maximalist • Self-hosted • Zero cloud**
 
-[jordanpartridge.us](https://jordanpartridge.us)
+[jordanpartridge.us](https://jordanpartridge.us) · [jordan@patridge.rocks](mailto:jordan@patridge.rocks)
 
 </div>


### PR DESCRIPTION
Closes #7.

## Summary

Reshapes the profile README around the actual 2026 thesis — devs came home to the terminal — and kills the warped CONDUIT ASCII banner. Tone shifts from "Developer Liberation Platform / meeting people" toward builder-first, terminal-maximalist, self-hosted by choice. Promotes `the-shit — Scaling humans into tomorrow` to a section header and adds a dedicated `On the Bike` block (biker, not cyclist — fat bike + e-bike, coffee and mobility, not the Tour).

## Changes

- **Header**: Oversized warping ASCII → scaling terminal-prompt block (`jordan@odin:~$ whoami` / `uptime`).
- **Hero**: Drop "meet people" / breakfast-club / three-pillars framing; replace with the 2026 terminal thesis.
- **What I Ship**: Tightened to the current lineup — `conduit-ui`, `the-shit`, `prefrontal-cortex`, `github-client`, `strava-client`, `fat-bike-corps`. One line each, utility-for-agents framing.
- **On the Bike**: New dedicated section. `<!-- STRAVA:START --> / <!-- STRAVA:END -->` markers reserved for a future `signal.jordanpartridge.us/widgets/readme.svg` endpoint that prefrontal-cortex will feed (Lexi-architected — separate issue inbound on `prefrontal-cortex`).
- **Built On**: Nod to [Aaron Francis](https://github.com/aarondfrancis) / [Solo](https://github.com/aarondfrancis/solo) — the dev harness I was going to build until a real one shipped a better one.
- **Currently**: Live-update markers (`<!-- CURRENT:START --> / <!-- CURRENT:END -->`) for later GitHub Action automation. Current bullets: agent-swarm infra on conduit-ui spine, package push, ride volume, Lexi running point.
- **Ecosystem mermaid diagram**: Dropped. Old `CONDUIT PLATFORM` shape, no longer matches. Will revisit if it adds value.
- **Footer**: `Terminal maximalist • Self-hosted • Zero cloud`.

## Follow-ups (separate issues)

- `prefrontal-cortex`: spec `/widgets/readme.svg` endpoint (5-min cache, raw signal from Strava/HRV/conduit-ui release, Lexi-generated copy line). Lexi already has the v1 architecture in hand.
- Consider a GitHub Action cron to rewrite the `CURRENT:*` markers from prefrontal-cortex data on a schedule.

## Test plan

- [ ] Render preview on GitHub — confirm the terminal-prompt header scales clean on wide monitors (was the original bug).
- [ ] Confirm shields render with the new badge styles.
- [ ] Confirm all repo links resolve.
- [ ] Visual gut-check: does this read like me in 2026, not Q4-2024 me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Redesigned README with a more compact and streamlined layout.
  * Added new navigation badges and footer links for improved accessibility.
  * Refreshed current initiatives and project overview information.
  * Updated content structure for clearer presentation of key details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jordanpartridge/jordanpartridge/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->